### PR TITLE
Ignore special characters in debug.log

### DIFF
--- a/efi.py
+++ b/efi.py
@@ -108,7 +108,7 @@ class Command_efi(gdb.Command):
 
     def get_drivers(self, drivers):
         print('Looking for addresses in ' + self.LOG_FILE)
-        with open(self.LOG_FILE, 'r') as f:
+        with open(self.LOG_FILE, 'r', errors='ignore') as f:
             for match in re.finditer(self.A_PATTERN, f.read()):
                 name = match.group(2)
                 if not drivers or name in drivers or name + '.efi' in drivers:


### PR DESCRIPTION
This change makes efi.py could run when there are garbage characters in debug.log.

Original error log when using efi.py in gdb.
```
Python Exception <class 'UnicodeDecodeError'> 'utf-8' codec can't decode byte 0xaf in position 592896: invalid start byte: 
Error occurred in Python command: 'utf-8' codec can't decode byte 0xaf in position 592896: invalid start byte
Error occurred in Python command: 'utf-8' codec can't decode byte 0xaf in position 592896: invalid start byte (from interpreter-exec console "efi -64")
```